### PR TITLE
feat: Allow wildcard references (master)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,7 @@ variable "repositories" {
     # organization/repository format used by GitHub.
     condition = length([
       for repo in var.repositories : 1
-      if length(regexall("^project_path:[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/-]+|\\*)$", repo)) > 0
+      if length(regexall("^project_path:[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/*-]+|\\*)$", repo)) > 0
     ]) == length(var.repositories)
     error_message = "Repositories must be specified in the organization/repository format."
   }


### PR DESCRIPTION
# Allow Wildcard references in repositories variable

## 📒 Description

In order to not specify every branch/tags allowed to assume the role, we should support wildcards in the repository list as used in the following working example https://gitlab.com/guided-explorations/aws/configure-openid-connect-in-aws/#steps.

## 🕶️ Types of changes
- [x] Enhancement/optimization

### 🤯 List of changes
Update repository variable regex
