### PR TITLE
fix: Revert "no \ needed?" and add support for StringLike wildcards in project_path

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,7 @@ variable "project_paths" {
     # namespace/project format used by GitLab.
     condition = length([
       for path in var.project_paths : 1
-      if length(regexall("project_path:[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/-]+|\\*)$", path)) > 0
+      if length(regexall("project_path:[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:?*/-]+|\\*)$", path)) > 0
     ]) == length(var.project_paths)
     error_message = "Projects must be specified in the \"project_path:namespace/project\" format."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "project_paths" {
       for path in var.project_paths : 1
       if length(regexall("project_path:[A-Za-z0-9_.-]+?/([A-Za-z0-9_.:/-]+|\\*)$", path)) > 0
     ]) == length(var.project_paths)
-    error_message = "Projects must be specified in the "project_path:namespace/project" format."
+    error_message = "Projects must be specified in the \"project_path:namespace/project\" format."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "role_description" {
 }
 
 variable "project_paths" {
-  description = "List of GitLab namesapce/project names authorized to assume the role."
+  description = "List of GitLab namespace/project names authorized to assume the role."
   type        = list(string)
   default     = []
 


### PR DESCRIPTION
This reverts commit ccf5ae19bfd4b819513a5bf1d3c7f8dbb5f777c2.

That commit broke the module as the double-quotes must be escaped in the variables.tf file.

P.S. Thanks for writing this, big help!